### PR TITLE
Remove extra ']'

### DIFF
--- a/bin/dsnap-sync
+++ b/bin/dsnap-sync
@@ -3040,7 +3040,7 @@ verify_snapper_structure () {
 		fi
 		cmd="$ssh btrfs subvolume create $backup_root/$snapper_snapshots 2>/dev/null"
        		ret=$(eval $cmd)
-		if [ $? -ne 0 ]]; then
+		if [ $? -ne 0 ]; then
 		    printf "${RED}Error: ${MAGENTA}Creation of snapper subvolume ${GREEN}%s${MAGENTA} failed${NO_COLOR}\n" \
 		           "$backup_root/$snapper_snapshots"
 		    return 1


### PR DESCRIPTION
Resolves the following:

```
$ dsnap-sync
   0) /var/lib/docker (type=btrfs,uuid=352184f1-63a4-4d86-9d81-f5b9d7573f1d,subvolid=5,subvol=/)
   1) /var/lib/docker/btrfs (type=btrfs,uuid=352184f1-63a4-4d86-9d81-f5b9d7573f1d,subvolid=5,subvol=/btrfs)
   2) /run/media/root/fedora-backup (type=btrfs,uuid=e1eaca10-c1b8-434d-84f1-f6e1f45182a7,subvolid=5,subvol=/)
   x) Exit
Enter a number: 2
/usr/bin/dsnap-sync: line 3043: [: missing `]'
```