### PR TITLE
Don't rely on killall

### DIFF
--- a/bin/dsnap-sync
+++ b/bin/dsnap-sync
@@ -104,6 +104,7 @@ check_prerequisites () {
     which findmnt >/dev/null 2>&1 || { printf "'findmnt' is not installed." && exit 1; }
     which systemd-cat >/dev/null 2>&1 || { printf "'systemd-cat' is not installed." && exit 1; }
     which snapper >/dev/null 2>&1 || { printf "'snapper' is not installed." && exit 1; }
+    which systemd >/dev/null 2>&1 || { printf "$progname relies on the systemd init system." && exit 1; }
 
     # optional binaries:
     which attr >/dev/null 2>&1 || { printf "'attr' is not installed." && exit 1; }
@@ -2024,7 +2025,7 @@ run_finalize () {
 	    printf "${MAGENTA}Kill runnint ${GREEN}snapperd${MAGENTA} on target id:${GREEN}'%s'${NO_COLOR} ...\n" \
 		   "$snapperd_pid"
 	fi
-	$(eval $ssh killall -SIGTERM snapperd 2>/dev/null)
+	$(eval $ssh systemctl stop snapperd 2>/dev/null)
 
 	if [ $verbose -ge 3 ]; then
 	    printf "${MAGENTA}Identify snapper id ${GREEN}'%s'${MAGENTA} on target for configuration ${GREEN}'%s'${NO_COLOR} ...\n" \

--- a/bin/dsnap-sync
+++ b/bin/dsnap-sync
@@ -2018,14 +2018,14 @@ run_finalize () {
 	local ii_max=20
 	local ii_sleep=15
 
-	# Solution2: kill running snapperd
+	# Solution2: restart running snapperd
 	#            -> will restart and sync any unseen dependencies
 	snapperd_pid=$(eval $ssh pgrep snapperd)
 	if [ $verbose -ge 3 ]; then
-	    printf "${MAGENTA}Kill runnint ${GREEN}snapperd${MAGENTA} on target id:${GREEN}'%s'${NO_COLOR} ...\n" \
+	    printf "${MAGENTA}Restarting ${GREEN}snapperd${MAGENTA} on target id:${GREEN}'%s'${NO_COLOR} ...\n" \
 		   "$snapperd_pid"
 	fi
-	$(eval $ssh systemctl stop snapperd 2>/dev/null)
+	$(eval $ssh systemctl restart snapperd 2>/dev/null)
 
 	if [ $verbose -ge 3 ]; then
 	    printf "${MAGENTA}Identify snapper id ${GREEN}'%s'${MAGENTA} on target for configuration ${GREEN}'%s'${NO_COLOR} ...\n" \


### PR DESCRIPTION
Hi,

killall is not installed by default on Debian and a lot of Debian derivatives . The script doesn't check for the psmisc package so the error is a bit hard to debug.

This pull request relies on systemctl to restart snapperd. This seems clean because the script already relies on systemd. 

**Possible alternatives to this pull request:**

- Send a real SIGTERM to snapperd with systemctl kill 
- Check for the psmisc at the top of the script 
- Use pkill (as alternative or if killall is not present)